### PR TITLE
Fix: 'home' crate to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ name = "linux-media-sys"
 version = "0.3.0"
 dependencies = [
  "bindgen",
+ "home",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/eldesh/linux-media-sys"
 
 [dependencies]
 libc = "0.2.170"
+home = "=0.5.5"
 
 [build-dependencies]
 bindgen = "0.66.0"


### PR DESCRIPTION
Fixed home crate version to 0.5.5 to support rustc 1.65.0.