### PR TITLE
Fix: unsupported directive `cargo::key=value`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    println!("cargo::rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=wrapper.h");
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for


### PR DESCRIPTION
Fix: unsupported directive `cargo::key=value`

> error: unsupported output in build script of `linux-media-sys v0.4.0`: `cargo::rerun-if-changed=wrapper.h`
> Found a `cargo::key=value` build directive which is reserved for future use.
> Either change the directive to `cargo:key=value` syntax (note the single `:`) or upgrade your version of Rust.
> See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.